### PR TITLE
added macros for database tests

### DIFF
--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -410,7 +410,7 @@ impl Database for Tree {
 
 impl BatchDatabase for Tree {
     type Batch = sled::Batch;
-
+ 
     fn begin_batch(&self) -> Self::Batch {
         sled::Batch::default()
     }
@@ -466,8 +466,8 @@ mod test {
         }
     }
     
-    run_tests_with_constructor![
-        getter get_tree(),
+    run_tests_with_initialiser![
+        init get_tree(),
         tests(
             test_script_pubkey,
             test_batch_script_pubkey,

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -410,7 +410,6 @@ impl Database for Tree {
 
 impl BatchDatabase for Tree {
     type Batch = sled::Batch;
- 
     fn begin_batch(&self) -> Self::Batch {
         sled::Batch::default()
     }
@@ -465,7 +464,7 @@ mod test {
                 .unwrap()
         }
     }
-    
+
     run_tests_with_initialiser![
         init get_tree(),
         tests(

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -8,6 +8,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // You may not use this file except in accordance with one or both of these
 // licenses.
+
 use std::convert::TryInto;
 
 use sled::{Batch, Tree};
@@ -419,7 +420,6 @@ impl BatchDatabase for Tree {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use lazy_static::lazy_static;
@@ -427,8 +427,6 @@ mod test {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use sled::{Db, Tree};
-
-    use crate::make_tests;
 
     static mut COUNT: usize = 0;
 
@@ -468,9 +466,9 @@ mod test {
         }
     }
     
-    make_tests![
-        @getter get_tree(),
-        @tests(
+    run_tests_with_constructor![
+        getter get_tree(),
+        tests(
             test_script_pubkey,
             test_batch_script_pubkey,
             test_iter_script_pubkey,

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -479,10 +479,8 @@ impl ConfigurableDatabase for MemoryDatabase {
     }
 }
 
-
 #[cfg(test)]
 mod test {
-
     use super::MemoryDatabase;
 
     fn get_tree() -> MemoryDatabase {

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -489,8 +489,8 @@ mod test {
         MemoryDatabase::new()
     }
 
-    run_tests_with_constructor![
-        getter get_tree(),
+    run_tests_with_initialiser![
+        init get_tree(),
         tests(
             test_script_pubkey,
             test_batch_script_pubkey,

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -482,7 +482,6 @@ impl ConfigurableDatabase for MemoryDatabase {
 
 #[cfg(test)]
 mod test {
-    use crate::make_tests;
 
     use super::MemoryDatabase;
 
@@ -490,9 +489,9 @@ mod test {
         MemoryDatabase::new()
     }
 
-    make_tests![
-        @getter get_tree(),
-        @tests(
+    run_tests_with_constructor![
+        getter get_tree(),
+        tests(
             test_script_pubkey,
             test_batch_script_pubkey,
             test_iter_script_pubkey,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -219,19 +219,6 @@ pub(crate) trait DatabaseUtils: Database {
 
 impl<T: Database> DatabaseUtils for T {}
 
-#[macro_export]
-#[doc(hidden)]
-macro_rules! make_tests {
-    (@getter $fn_name:ident(), @tests ( $($x:tt) , + $(,)? )) => {
-        $(
-          #[test]
-          fn $x()
-          {
-            $crate::database::test::$x($fn_name());
-          }
-        )+
-    };
-}
 
 #[cfg(test)]
 pub mod test {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -219,7 +219,6 @@ pub(crate) trait DatabaseUtils: Database {
 
 impl<T: Database> DatabaseUtils for T {}
 
-
 #[cfg(test)]
 pub mod test {
     use std::str::FromStr;

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -976,7 +976,7 @@ pub fn migrate(conn: &Connection) -> rusqlite::Result<()> {
 
 #[cfg(test)]
 pub mod test {
-    use crate::{database::SqliteDatabase, make_tests};
+    use crate::{database::SqliteDatabase};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn get_database() -> SqliteDatabase {
@@ -986,9 +986,9 @@ pub mod test {
         SqliteDatabase::new(String::from(dir.to_str().unwrap()))
     }
 
-    make_tests![
-        @getter get_database(),
-        @tests(
+    run_tests_with_constructor![
+        getter get_database(),
+        tests(
             test_script_pubkey,
             test_batch_script_pubkey,
             test_iter_script_pubkey,

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -976,7 +976,7 @@ pub fn migrate(conn: &Connection) -> rusqlite::Result<()> {
 
 #[cfg(test)]
 pub mod test {
-    use crate::{database::SqliteDatabase};
+    use crate::database::SqliteDatabase;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn get_database() -> SqliteDatabase {

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -986,8 +986,8 @@ pub mod test {
         SqliteDatabase::new(String::from(dir.to_str().unwrap()))
     }
 
-    run_tests_with_constructor![
-        getter get_database(),
+    run_tests_with_initialiser![
+        init get_database(),
         tests(
             test_script_pubkey,
             test_batch_script_pubkey,

--- a/src/testutils/mod.rs
+++ b/src/testutils/mod.rs
@@ -396,8 +396,8 @@ pub mod helpers {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! run_tests_with_constructor {
-    (getter $fn_name:ident(), tests ( $($x:tt) , + $(,)? )) => {
+macro_rules! run_tests_with_initialiser {
+    (init $fn_name:ident(), tests ( $($x:tt) , + $(,)? )) => {
         $(
           #[test]
           fn $x()

--- a/src/testutils/mod.rs
+++ b/src/testutils/mod.rs
@@ -243,7 +243,7 @@ macro_rules! doctest_wallet {
         let descriptors = testutils!(@descriptors (descriptor) (descriptor));
 
         let mut db = MemoryDatabase::new();
-        let txid = populate_test_db!(
+        let txid = populate_test_db(
             &mut db,
             testutils! {
                 @tx ( (@external descriptors, 0) => 500_000 ) (@confirmations 1)

--- a/src/testutils/mod.rs
+++ b/src/testutils/mod.rs
@@ -393,3 +393,17 @@ pub mod helpers {
         (wallet, descriptors, txid)
     }
 }
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! run_tests_with_constructor {
+    (getter $fn_name:ident(), tests ( $($x:tt) , + $(,)? )) => {
+        $(
+          #[test]
+          fn $x()
+          {
+            $crate::database::test::$x($fn_name());
+          }
+        )+
+    };
+}


### PR DESCRIPTION
added macros for database tests to remove the repetitive test and make it simple using declarative macros. Macros are inserted 

in memory.rs,keyvalue.rs.

Co-authored-by :  SanthoshAnguluri <santhoshanguluri15@gmail.com>